### PR TITLE
Divide code and configuration, move to compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,5 @@ RUN apt install -y ros-humble-std-msgs
 RUN apt install -y ros-humble-can-msgs
 RUN rosdep init
 RUN rosdep update --rosdistro humble
-COPY mmr-kria-drive/ /home
-RUN rosdep install --from-paths /home/src --rosdistro humble --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"
 RUN apt install ros-humble-sensor-msgs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,19 @@
 FROM arm64v8/ubuntu:22.04
-RUN apt update && apt install -y locales
-RUN locale-gen en_US en_US.UTF-8
-RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-RUN export LANG=en_US.UTF-8
-RUN apt install -y software-properties-common
-RUN add-apt-repository universe
-RUN apt update && apt install curl -y
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-RUN apt update
-RUN apt install -y python3-flake8-docstrings 
-RUN apt install -y python3-pip 
-RUN apt install -y python3-pytest-cov 
-RUN DEBIAN_FRONTEND=noninteractive apt install -y ros-dev-tools
-RUN apt install -y ros-humble-ament-cmake
-RUN apt install -y ros-humble-rclcpp
-RUN apt install -y ros-humble-geometry-msgs
-RUN apt install -y ros-humble-std-msgs
-RUN apt install -y ros-humble-can-msgs
-RUN rosdep init
-RUN rosdep update --rosdistro humble
-RUN apt install ros-humble-sensor-msgs
+RUN apt update && apt install -y locales \
+    && locale-gen en_US en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+    && export LANG=en_US.UTF-8 \
+    && apt install -y software-properties-common \
+    && add-apt-repository universe \
+    && apt update && apt install -y curl
 
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
+    python3-flake8-docstrings python3-pip python3-pytest-cov \
+    ros-dev-tools ros-humble-ament-cmake ros-humble-rclcpp \
+    ros-humble-geometry-msgs ros-humble-std-msgs ros-humble-can-msgs
+
+RUN rosdep init && rosdep update --rosdistro humble && apt install ros-humble-sensor-msgs
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Documentazione Dockerfile per Cross-Compilazione
 
 ---
-N.B: PER UTLIIZZARE IL DOCKERFILE BISOGNA TROVARSI NELLA CARTELLA CHE CONTIENE mmr-kria-drive, oppure modifica il dockerfile alla riga di "COPY" e metti il percorso 
 
+## Usage
+Place yourself in the folder containing the docker-compose.yml (this repository root directory).
 
-è stato creato un Dockerfile (il quale crea un immagine docker) per lanciare un container di questa immagine per cross-compilare i nodi ROS2.
+Run:
+```SRC_PATH=<mmr-kria-drive-path> docker compose run --rm mmr-cross-compile-container```
+
+Set `mmr-kria-drive-path` to the relative or absolute path of the `mmr-kria-drive` source code.
+
+Once inside the container, run `rosdep install --from-paths src --rosdistro humble --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers"` to install additional dependencies.
+
+È stato creato un Dockerfile (il quale crea un immagine docker) per lanciare un container di questa immagine per cross-compilare i nodi ROS2.
+
+---
 
 ## Motivazione
 
@@ -50,21 +60,24 @@ Punti importanti
 - **ros-humble-***: tutti i pacchetti ros-humble-* sono le librerie utilizzate all’interno dei nodi ros2, in particolare in “canbus_bridge” e “canopen_bridge” al momento della scrittura di questa documentazione. Se compilando questi nodi viene generato un errore riguardate un pacchetto mancante, prima provare a fare il source delle variabili di ambiente (source ./install/setupt.bash && source /opt/ros/humble/setup.bash), se l’errore persiste allora installa il pacchetto richiesto a mano.
 
 > **Suggerimento**: esegui “apt search <nome del pacchetto>” e scarica quello che ha questa formattazione “ros-humble-<nome del pacchetto>”
-> 
+>
 
-## Creazione Immagine
+## Manual Procedure
+If u are not willing to use the compose-based proceudre, u can always opt for the manual procedure which involves build and interactive execution of the image.
+
+### Creazione Immagine
 
 ```bash
-docker build -t <nome immagine> <path> --platform=linux/arm64/v8
+docker build -t mmr-cross-compile <path> --platform=linux/arm64/v8
 ```
 
 - **nome immagine**: è il nome che vogliamo dare all’immagine che creerà il container per la corss-compilazione
 - **path** : è il path alla CARTELLA che contiene il Dockerfile
 
-## Creazione Container
+### Creazione Container
 
 ```bash
- docker run --platform=linux/arm64/v8 --rm -it --volume=mmr-kria-drive:/home <nome immagine> 
+ docker run --platform=linux/arm64/v8 --rm -it --volume=<mmr-kria-drive-path>:/home/mmr-kria-drive <nome immagine> 
 
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  mmr-cross-compile-container:
+    image: mmr-cross-compile-3
+    platform: linux/arm64
+    build:
+      dockerfile: ./dockerfile
+    volumes:
+      - ${SRC_PATH}:/home/mmr-kria-drive
+    working_dir: /home/mmr-kria-drive
+    stdin_open: true
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   mmr-cross-compile-container:
-    image: mmr-cross-compile-3
+    image: mmr-cross-compile
     platform: linux/arm64
     build:
-      dockerfile: ./dockerfile
+      dockerfile: ./Dockerfile
     volumes:
       - ${SRC_PATH}:/home/mmr-kria-drive
     working_dir: /home/mmr-kria-drive


### PR DESCRIPTION
- [x] Fixed #1 
- [x] Automate container execution with compose
- [x] Update README with new instructions
- [ ] Automate `rosdep` execution through a entrypoint setup script -> TODO @doclorenzo 